### PR TITLE
ci: Remove `node_modules` and `package-lock.json` before `npm install…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Build Admin App
         working-directory: admin-app
         run: |
-          rm -f package-lock.json
+          rm -rf admin-app/node_modules admin-app/package-lock.json
           npm install
           npm run build
 
       - name: Build Portal App
         working-directory: portal-app
         run: |
-          rm -f package-lock.json
+          rm -rf portal-app/node_modules portal-app/package-lock.json
           npm install
           npm run build
 


### PR DESCRIPTION
…` for clean builds in admin and portal apps.