### PR TITLE
fix: attach auth token to private media proxy image URLs

### DIFF
--- a/admin-app/src/utils/imageUtils.ts
+++ b/admin-app/src/utils/imageUtils.ts
@@ -46,6 +46,14 @@ export function getImageUrl(url: string | null | undefined): string {
     // Already an absolute URL (blob: for preview, http: for external)
     if (url.startsWith('http') || url.startsWith('blob:')) return url;
 
+    // Private Firebase media proxy: requires a token, since <img>/<iframe> tags
+    // can't send an Authorization header. Backend accepts it as ?token=.
+    if (url.includes('/portal/media')) {
+        const token = localStorage.getItem('adminToken') || localStorage.getItem('portalToken');
+        const sep = url.includes('?') ? '&' : '?';
+        return `${BACKEND_URL}/${url.replace(/^\//, '')}${token ? `${sep}token=${token}` : ''}`;
+    }
+
     // Relative backend path
     // Fallback: treat as a relative path to our backend image proxy.
     return `${BACKEND_URL}/${url.replace(/^\//, '')}`;

--- a/portal-app/src/utils/imageUtils.ts
+++ b/portal-app/src/utils/imageUtils.ts
@@ -48,6 +48,14 @@ export function getImageUrl(url: string | null | undefined): string {
     // Already an absolute URL
     if (url.startsWith('http') || url.startsWith('blob:')) return url;
 
+    // Private Firebase media proxy: requires a token, since <img>/<iframe> tags
+    // can't send an Authorization header. Backend accepts it as ?token=.
+    if (url.includes('/portal/media')) {
+        const token = localStorage.getItem('portalToken');
+        const sep = url.includes('?') ? '&' : '?';
+        return `${BACKEND_URL}/${url.replace(/^\//, '')}${token ? `${sep}token=${token}` : ''}`;
+    }
+
     // Fallback: treat as a relative path to our backend image proxy.
     return `${BACKEND_URL}/${url.replace(/^\//, '')}`;
 }


### PR DESCRIPTION
## Summary
- Matrimony candidate photos and manual forms are stored in Firebase Storage behind a private backend proxy (`/api/v1/portal/media?path=...`) that requires authentication.
- `<img>`/`<iframe>` tags can't send `Authorization` headers, and the backend already supports a `?token=` query fallback for exactly this case, but `getImageUrl()` in both apps never appended it.
- Result: candidate photos/uploaded forms failed to load (401 Unauthorized) in both the admin dashboard and member portal.

## Fix
- `admin-app/src/utils/imageUtils.ts` and `portal-app/src/utils/imageUtils.ts`: when the resolved URL is a `/portal/media` proxy path, append `?token=` (or `&token=`) using the stored `adminToken`/`portalToken` from `localStorage`.

## Test plan
- [ ] Log into admin dashboard, open Matrimony page, confirm candidate photos and uploaded forms render
- [ ] Log into member portal, open Matrimony page, confirm candidate photos and uploaded forms render
- [ ] Confirm \`tsc --noEmit\` passes for both apps (verified locally)