### PR TITLE
fix: expense bill proof viewer 404s (media URL not resolved)

### DIFF
--- a/admin-app/src/pages/Expenses.tsx
+++ b/admin-app/src/pages/Expenses.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { useAdminAuth } from '../context/AdminAuthContext';
 import { expenseService } from '../services/expenseService';
 import type { ExpenseData } from '../services/expenseService';
+import { getImageUrl } from '../utils/imageUtils';
 
 interface Transaction extends ExpenseData {}
 
@@ -601,7 +602,7 @@ export default function Expenses() {
                                 <button onClick={() => { setZoom(1); setRotation(0); }} className="p-2.5 bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 rounded-xl hover:text-indigo-600 transition-all" title="Reset View"><Maximize2 size={18} /></button>
                                 <div className="w-px h-6 bg-slate-200 dark:bg-slate-800 mx-1" />
                                 <button 
-                                    onClick={() => window.open(selectedExpense.attachment_url, '_blank')}
+                                    onClick={() => window.open(getImageUrl(selectedExpense.attachment_url), '_blank')}
                                     className="p-2.5 bg-indigo-50 dark:bg-indigo-900/40 text-indigo-600 dark:text-indigo-400 rounded-xl hover:bg-indigo-600 hover:text-white transition-all"
                                     title="Open Externally"
                                 >
@@ -624,7 +625,7 @@ export default function Expenses() {
                                 className="bg-white shadow-2xl origin-center max-w-full"
                             >
                                 <iframe 
-                                    src={`${selectedExpense.attachment_url}#toolbar=0`} 
+                                    src={`${getImageUrl(selectedExpense.attachment_url)}#toolbar=0`}
                                     className="w-[800px] h-[1100px] border-none"
                                     title="Bill Proof"
                                 />


### PR DESCRIPTION
## Summary
Redo of a fix that was accidentally lost: PR #119 was merged in between two pushes to its branch, so the second commit (this fix) never actually landed on `main`.

- `attachment_url` on expenses is the private `/api/v1/portal/media?path=...` proxy path — same mechanism as matrimony candidate photos.
- The bill/proof viewer used the raw path directly in `window.open()` and an `<iframe src>`, so it resolved against the frontend's own origin (`nikhilaodishapandarasamaja.in`, a GitHub Pages site) instead of the backend, and had no auth token attached.
- Result: "File not found" (GitHub Pages 404) when viewing/opening any expense bill proof.

## Fix
`admin-app/src/pages/Expenses.tsx`: wrap `attachment_url` with `getImageUrl()` (same helper that already fixed matrimony photos) for both the "Open Externally" button and the inline `<iframe>` preview.

## Test plan
- [ ] Admin dashboard → Expense Tracker → click an expense with an attached PDF → confirm the preview panel renders the PDF instead of "File not found"
- [ ] Click "Open Externally" → confirm it opens the PDF in a new tab instead of a GitHub Pages 404